### PR TITLE
Select Yorkie API endpoint by JEKYLL_ENV

### DIFF
--- a/demo.md
+++ b/demo.md
@@ -65,8 +65,13 @@ layout: default
 
   async function main() {
     try {
-      // 01. create client with RPCAddr(envoy) then activate it.
+      {% if jekyll.environment == "production" %}
+      // Production build uses https://yorkie.dev/api
       const client = yorkie.createClient('/api');
+      {% else %}
+      // yorkie-js-sdk serves its envoy endpoint as localhost:8080
+      const client = yorkie.createClient('http://localhost:8080');
+      {% endif %}
       await client.activate();
 
       await createTextExample(client, placeholder);

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,5 +3,10 @@
   to = "https://yorkie.dev/api/:splat"
   status = 200
 
+[build]
+  publish = "_site/"
+  command = "jekyll build"
+  environment = { JEKYLL_ENV = "production" }
+
 [dev]
   publish = "_site" # If you use a _redirect file, provide the path to your static content folder


### PR DESCRIPTION
Currently, while testing the yorkie-homepage, we have to change the API endpoint manually.
So I introduced `JEKYLL_ENV` and added a condition statement with `jekyll.environment`.