### PR TITLE
Add markdown example

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,6 +18,10 @@
 <script src="https://cdn.quilljs.com/1.3.6/quill.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/quill-cursors@3.0.0/dist/quill-cursors.js"></script>
 
+<!-- SimpeMDE -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css">
+<script src="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js"></script>
+
 <!-- Style -->
 <link href="/static/css/main.css" rel="stylesheet">
 

--- a/demo.md
+++ b/demo.md
@@ -10,6 +10,11 @@ layout: default
     <div class="text">
       <textarea id="text-editor">Type text here</textarea>
     </div>
+    <h3>Markdown</h3>
+    <p>Markdown example also uses Text.</p>
+    <div class="markdown">
+      <textarea id="markdown-editor">Type markdown here</textarea>
+    </div>
     <h3>Quill</h3>
     <p>The Quill example uses custom CRDT type, RichText.</p>
     <p>For more details: <a href="https://github.com/yorkie-team/yorkie-js-sdk/blob/master/dist/quill.html">quill.html</a></p>
@@ -60,6 +65,7 @@ layout: default
 </section>
 <script src="/static/js/demo-util.js"></script>
 <script src="/static/js/demo-codemirror.js"></script>
+<script src="/static/js/demo-markdown.js"></script>
 <script src="/static/js/demo-quill.js"></script>
 <script src="/static/js/demo-drawing.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/vue"></script>
@@ -67,6 +73,7 @@ layout: default
 
 <script>
   const placeholder = document.getElementById('text-editor');
+  const markdownPlaceholder = document.getElementById('markdown-editor');
   const drawingPanel = document.getElementById('drawing-panel');
   const kanbanBoard = document.getElementById('kanban-board');
   const quillEditor = document.getElementById('quill-editor');
@@ -83,6 +90,7 @@ layout: default
       await client.activate();
 
       await createTextExample(client, placeholder);
+      await createMarkdownExample(client, markdownPlaceholder);
       await createQuillExample(client, quillEditor);
       await createDrawingExample(client, drawingPanel);
       await createKanbanExample(client, kanbanBoard);

--- a/static/js/demo-markdown.js
+++ b/static/js/demo-markdown.js
@@ -1,0 +1,148 @@
+const createMarkdownExample = (() => {
+  const colors = ['#FECEEA', '#FEF1D2', '#A9FDD8', '#D7F8FF', '#CEC5FA'];
+  let nextColorIdx = 0;
+
+// https://github.com/codemirror/CodeMirror/pull/5619
+  function replaceRangeFix(cm, text, from, to, origin) {
+    const adjust = cm.listSelections().findIndex(({anchor, head}) => {
+      return CodeMirror.cmpPos(anchor, head) === 0 && CodeMirror.cmpPos(anchor, from) === 0;
+    });
+    cm.operation(() => {
+      cm.replaceRange(text, from, to, origin);
+      if (adjust > -1) {
+        const range = cm.listSelections()[adjust];
+        if (range && CodeMirror.cmpPos(range.head, CodeMirror.changeEnd({from, to, text})) === 0) {
+          const ranges = cm.listSelections().slice();
+          ranges[adjust] = {anchor: from, head: from};
+          cm.setSelections(ranges);
+        }
+      }
+    });
+  }
+
+  function displayRemoteSelection(cm, change, selectionMap) {
+    let color;
+    if (selectionMap.has(change.actor)) {
+      const selection = selectionMap.get(change.actor);
+      color = selection.color;
+      selection.marker.clear();
+    } else {
+      color = colors[nextColorIdx];
+      nextColorIdx = (nextColorIdx + 1) % colors.length;
+    }
+
+    if (change.from === change.to) {
+      const pos = cm.posFromIndex(change.from);
+      const cursorCoords = cm.cursorCoords(pos);
+      const cursorElement = document.createElement('span');
+      cursorElement.style.borderLeftWidth = '2px';
+      cursorElement.style.borderLeftStyle = 'solid';
+      cursorElement.style.borderLeftColor = color;
+      cursorElement.style.marginLeft = cursorElement.style.marginRight = '-1px';
+      cursorElement.style.height = (cursorCoords.bottom - cursorCoords.top) * 0.9 + 'px';
+      cursorElement.setAttribute('data-actor-id', change.actor);
+      cursorElement.style.zIndex = 0;
+
+      selectionMap.set(change.actor, {
+        color: color,
+        marker: cm.setBookmark(pos, {
+          widget: cursorElement,
+          insertLeft: true
+        })
+      });
+    } else {
+      const fromPos = cm.posFromIndex(Math.min(change.from, change.to));
+      const toPos = cm.posFromIndex(Math.max(change.from, change.to));
+
+      selectionMap.set(change.actor, {
+        color: color,
+        marker: cm.markText(fromPos, toPos, {
+          css: `background: ${color}`,
+          insertLeft: true
+        })
+      });
+    }
+  }
+
+  const selectionMap = new Map();
+  async function createMarkdownExample(client, placeholder) {
+    // 01. create a document then attach it into the client.
+    const doc = yorkie.createDocument('examples', `markdown-${getYYYYMMDD()}`);
+    await client.attach(doc);
+
+    doc.update((root) => {
+      if (!root.content) {
+        const text = root.createText('content');
+        text.edit(0, 0, '# Hello Markdown');
+      }
+    }, 'create content if not exists');
+    await client.sync();
+
+    // 02. create an instance of codemirror.
+    const simplemde = new SimpleMDE({ element: placeholder });
+    const codemirror = simplemde.codemirror;
+
+    // 03. bind the document with the codemirror.
+    // 03-1. codemirror to document(local).
+    codemirror.on('beforeChange', (cm, change) => {
+      if (change.origin === 'yorkie' || change.origin === 'setValue') {
+        return;
+      }
+
+      const from = cm.indexFromPos(change.from);
+      const to = cm.indexFromPos(change.to);
+      const content = change.text.join('\n');
+
+      doc.update((root) => {
+        root.content.edit(from, to, content);
+      }, `update content by ${client.getID()}`);
+
+      console.log(`%c local: ${from}-${to}: ${content}`, 'color: green');
+    });
+    codemirror.on('beforeSelectionChange', (cm, change) => {
+      // Fix concurrent issue.
+      // CAUTION: The following conditional statement ignores cursor changes
+      //          that occur while applying remote changes to CodeMirror
+      //          and handles only movement by keyboard and mouse.
+      if (!change.origin) {
+        return;
+      }
+
+      const from = cm.indexFromPos(change.ranges[0].anchor);
+      const to = cm.indexFromPos(change.ranges[0].head);
+
+      doc.update((root) => {
+        root.content.updateSelection(from, to);
+      }, `update selection by ${client.getID()}`);
+    });
+
+    // 03-2. document to codemirror(remote).
+    const text = doc.getRootObject().content;
+    text.onChanges((changes) => {
+      for (const change of changes) {
+        if (change.type === 'content') {
+          const actor = change.actor;
+          const from = change.from;
+          const to = change.to;
+          const content = change.content || '';
+
+          if (actor !== client.getID()) {
+            console.log(`%c remote: ${from}-${to}: ${content}`, 'color: skyblue');
+            const fromIdx = codemirror.posFromIndex(from);
+            const toIdx = codemirror.posFromIndex(to);
+            replaceRangeFix(codemirror, content, fromIdx, toIdx, 'yorkie');
+          }
+        } else if (change.type === 'selection') {
+          const actor = change.actor;
+          if (actor !== client.getID()) {
+            displayRemoteSelection(codemirror, change, selectionMap);
+          }
+        }
+      }
+    });
+
+    // 04. set initial value.
+    codemirror.setValue(text.getValue());
+  }
+  return createMarkdownExample
+})()


### PR DESCRIPTION
related: https://github.com/yorkie-team/yorkie-js-sdk/issues/73

Add markdown example with SimpleMDE using codemirror internally.

### [SimpleMDE](https://github.com/sparksuite/simplemde-markdown-editor)
> CodeMirror is the backbone of the project and parses much of the Markdown syntax as it's being written. This allows us to add styles to the Markdown that's being written. Additionally, a toolbar and status bar have been added to the top and bottom, respectively. Previews are rendered by Marked using GFM.

