### PR TITLE
Add anchors to heading tags in docs

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -33,4 +33,5 @@
   </main>
   {% include footer.html %}
 </body>
+<script src="/static/js/docs.js"></script>
 </html>

--- a/static/css/docs.scss
+++ b/static/css/docs.scss
@@ -5,16 +5,6 @@
     flex-direction: column;
   }
 
-  .docs-content {
-    h1, h2, h3, h4 {
-      margin-top: 1em;
-
-      &:first-child {
-        margin-top: 0.5em;
-      }
-    }
-  }
-
   .docs-menu {
     flex: 1;
 
@@ -44,6 +34,30 @@
 
   .docs-content {
     flex: 3;
+
+    h1, h2, h3, h4 {
+      margin-top: 1em;
+      position: relative;
+
+      &:first-child {
+        margin-top: 0.5em;
+      }
+
+      a.pilcrow {
+        left: -2em;
+        visibility: hidden;
+        position: absolute;
+        opacity: 0;
+        padding: 0.125em 1em 0.075em 1em;
+        font-size: 0.8em;
+        transition: all .2s ease-in-out;
+      }
+
+      &:hover a.pilcrow {
+        visibility: visible;
+        opacity: 1.0;
+      }
+    }
 
     p {
       margin: 0.5em 0 1em 0;

--- a/static/js/docs.js
+++ b/static/js/docs.js
@@ -1,4 +1,4 @@
-const headers = document.querySelectorAll('h2[id], h3[id]');
+const headers = document.querySelectorAll('h2[id], h3[id], h4[id]');
 for(var i = 0; i < headers.length; i++) {
   const node = headers[i];
   const anchor = document.createElement("a");

--- a/static/js/docs.js
+++ b/static/js/docs.js
@@ -1,0 +1,9 @@
+const headers = document.querySelectorAll('h2[id], h3[id]');
+for(var i = 0; i < headers.length; i++) {
+  const node = headers[i];
+  const anchor = document.createElement("a");
+  anchor.className = "pilcrow";
+  anchor.text = "\xb6";
+  anchor.href = "#" + node.id;
+  node.appendChild(anchor);
+};


### PR DESCRIPTION
This adds anchors to heading tags in docs. (#19)
Currently, it creates pilcrows only for `h2`, `h3`,  and `h4`. This could be extended for more headings like `h5`.
<img width="379" alt="Screen Shot 2020-09-23 at 3 46 09 AM" src="https://user-images.githubusercontent.com/579366/93924168-5778ce00-fd4f-11ea-95d5-6eb8502ca624.png">