### PR TITLE
Add a monospace font family for CodeMirror demo

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=0.8">
 
 <!-- Google fonts -->
-<link href="https://fonts.googleapis.com/css?family=Roboto+Slab:400,700|Signika+Negative:700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css?family=Roboto+Mono:400|Roboto+Slab:400,700|Signika+Negative:700&display=swap" rel="stylesheet">
 
 <!-- CodeMirror -->
 <link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.51.0/codemirror.min.css" />

--- a/static/css/demo.scss
+++ b/static/css/demo.scss
@@ -6,10 +6,11 @@
     justify-content: space-between;
     margin: 10px 0;
 
-    .CodeMirror,textarea {
+    .CodeMirror, textarea {
       border: 1px solid #ccc;
       border-radius: 5px;
       font-size: 1.25em;
+      font-family: $font-monospace;
       flex: 1;
       min-width: 360px;
       min-height: 120px;

--- a/static/css/variables.scss
+++ b/static/css/variables.scss
@@ -21,6 +21,7 @@ $color-black-1: #1e1f21;
 
 $font-brand: 'Signika Negative', serif;
 $font-primary: 'Roboto Slab', sans-serif;
+$font-monospace: 'Roboto Mono', monospace;
 
 $small-screen: 'screen and (max-width: 980px)';
 $large-screen: 'screen and (min-width: 1920px)';


### PR DESCRIPTION
We use CodeMirror as a source code editor but we've been displayed it with a variable-width, sans-serif font family.
So I put `Roboto Mono` for it.