### PR TITLE
Update ToC style for docs

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -13,7 +13,7 @@
               <h4>Documentation</h4>
               <hr>
               <ul>
-                {% assign sorteds = site.pages | sort: "order" %}
+                {% assign sorteds = site.pages | where: "layout", "docs" | sort: "order" %}
                 {% assign groups = sorteds | group_by: "category" %}
                 {% for group in groups %}
                   {% assign docs = group.items %}

--- a/static/css/docs.scss
+++ b/static/css/docs.scss
@@ -26,13 +26,19 @@
     }
 
     li {
+      margin: 0;
       a {
         color: $color-black-1;
+        display: block;
+        padding: 0.25em 0.5em;
       }
     }
     li.active {
       a {
-        color: #e6b602;
+        color: $color-primary;
+        background: $color-white-2;
+        border: 1px solid $color-gray-1;
+        border-radius: 4px;
       }
     }
     li.sub {

--- a/static/css/hero.scss
+++ b/static/css/hero.scss
@@ -1,7 +1,7 @@
 .hero {
   background: $color-black-1;
   padding: 4em 0;
-  color: #cca100;
+  color: $color-brand;
   border-bottom: 3px solid $color-brand;
 
   @media #{$small-screen} {

--- a/static/css/main.scss
+++ b/static/css/main.scss
@@ -17,6 +17,8 @@
 
 * {
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
   margin: 0;
   outline: 0;
   padding: 0;

--- a/static/css/variables.scss
+++ b/static/css/variables.scss
@@ -1,5 +1,5 @@
-$color-brand: #e6b602;
-$color-primary: #d8b01a;
+$color-brand: #efbc00;
+$color-primary: #e9ba0c;
 $color-secondary: #000;
 $color-alternative: #000;
 $color-content: #1d2d35;


### PR DESCRIPTION
 - Add filter for docs page with `where: "layout", "docs"` to remove useless empty items.
 - Update style and colors for better legibility.