### PR TITLE
Fix code block indentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ Yorkie is an open source document store for building collaborative applications 
 
 High-level overview of Yorkie is as follows:
 
- ```
+```
  Client "A" (Go)                 Agent                        MemDB or MongoDB
 ┌───────────────────┐           ┌────────────────────────┐   ┌───────────┐
 │  Document "D-1"   │◄─Changes─►│  Collection "C-1"      │   │ Changes   │
@@ -28,7 +28,7 @@ High-level overview of Yorkie is as follows:
 │  Query "Q-1"       │               ▲
 │ db[c-1].find({a:2})├───── Query────┘
 └────────────────────┘
- ```
+```
 
 The overall flows is as follows:
 


### PR DESCRIPTION
Unintended wrong indentation of code blocks (```) in markdown may cause rendering problems.
(See Client B and C lines)
Relative issue: #32 (but this won't fix it)

<img width="676" alt="Screen Shot 2022-02-19 at 10 04 43 PM" src="https://user-images.githubusercontent.com/579366/154802408-9b46129e-a914-4fd6-af0b-176869af25e8.png">
