### PR TITLE
Change monospace font to Fira Mono for fixing missing glyph issue #32

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,10 @@
 <meta name="viewport" content="width=device-width, initial-scale=0.8">
 
 <!-- Google fonts -->
-<link href="https://fonts.googleapis.com/css?family=Roboto+Mono:400|Roboto+Slab:400,700|Signika+Negative:700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Slab:400,700|Signika+Negative:700&display=swap">
+
+<!-- Fira Mono for code blocks -->
+<link rel="stylesheet" href="https://code.cdn.mozilla.net/fonts/fira.css">
 
 <!-- Yorkie -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/yorkie-js-sdk/0.2.0/yorkie-js-sdk.js" integrity="sha512-dXHlpblLNF9kii8c6xiwIxN1umag1mwAmeWDYNwphiZ2St++NlApnAr7ML22E2McpdxNNClHihs8oES+7bw4Xw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
@@ -26,7 +29,7 @@
 <script src="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js"></script>
 
 <!-- Style -->
-<link href="/static/css/main.css" rel="stylesheet">
+<link rel="stylesheet" href="/static/css/main.css">
 
 <!-- Google Analytics-->
 {% include analytics.html %}

--- a/static/css/variables.scss
+++ b/static/css/variables.scss
@@ -21,7 +21,7 @@ $color-black-1: #1e1f21;
 
 $font-brand: 'Signika Negative', serif;
 $font-primary: 'Roboto Slab', sans-serif;
-$font-monospace: 'Roboto Mono', monospace;
+$font-monospace: 'Fira Mono', monospace;
 
 $small-screen: 'screen and (max-width: 980px)';
 $large-screen: 'screen and (min-width: 1920px)';


### PR DESCRIPTION
`Roboto Mono` does not contain the necessary glyphs for rendering code block characters in docs.
Google Fonts also provides `Fira Mono`, but only serves language-related (e.g., Latin) characters within their web fonts.
We may use `text=` parameter to get extra glyphs and merge them onto Latin-only fonts. However, we should check every character in docs forever to get a proper glyph set.

So I used Mozilla's CDN – it comes with a bigger font size (approx. 66KiB) but contains enough glyphs for us.
This fixes #32.