### PR TITLE
Dyi919/docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,20 +8,20 @@ order: 10
 
 ## About Yorkie
 
-Yorkie is an open source document storage for building collaborative applications such as [Google Docs](https://docs.google.com/) and [Figma](https://www.figma.com/). To achieve that, Yorkie provides synchronization primitives such as JSON-like document([CRDT](https://crdt.tech/)), [Peer Awareness](/docs/peer-awareness) and [Authentication](/docs/auth-webhook).
+Yorkie is an open source document storage for building collaborative applications such as [Google Docs](https://docs.google.com/) and [Figma](https://www.figma.com/). To achieve that, Yorkie provides synchronization primitives such as a JSON-like Document([CRDT](https://crdt.tech/)), [Peer Awareness](/docs/peer-awareness) and [Authentication](/docs/auth-webhook).
 
-Unlike libraries such as AutoMerge and Yjs, it contains SDKs, server and DB, through which you can implement the co-editing feature with less effort.
+Unlike libraries such as AutoMerge and Yjs, it contains SDKs, a server, and a DB, enabling the implementation of the co-editing feature with less effort.
 
 Next, let's take a look at Yorkie's structure and how it works.
 
 ### Components
 
-Yorkie consists of Client, Document, and Server.
+Yorkie consists of Clients, Documents, and a Server.
 
-- [Client](/docs/js-sdk#client): Client is a normal client that can communicate with the Server. We can synchronize the changes of the document by using Client.
-- [Server](/docs/server): Server receives changes from Client, stores them in DB, and propagates the changes to Clients who subscribe to the Document.
-- [Document](/docs/js-sdk#document): Document is a CRDT-based data type. We can represent the model of the application through it, and we can edit it even while offline.
-- [Project](/docs/project): Project represents your service or application in Yorkie. For example, you might have separate projects for your application.
+- [Client](/docs/js-sdk#client): A Client is a normal client that can communicate with a Server. Changes on a Document can be synchronized by using a Client.
+- [Server](/docs/server): A Server receives changes from Clients, stores them in the DB, and propagates them to Clients who subscribe to Documents.
+- [Document](/docs/js-sdk#document): A Document is a CRDT-based data type through which the model of the application is represented. Clients can edit it even while offline.
+- [Project](/docs/project): A Project represents services or applications in Yorkie. Separate Projects can exist within a single application.
 
 ### How it works
 
@@ -47,9 +47,9 @@ A high-level overview of Yorkie is as follows:
 
 The overall flow is as follows:
 
- - Clients can have a replica of the Document representing an application model locally on several devices.
- - Each client can independently edit the document on his or her local devices, even while offline.
- - When a network connection is available, Yorkie figures out which changes need to be synced from one client to another, and brings them into the same state.
- - If the document is being changed concurrently on different devices, Yorkie automatically syncs the changes so that every replica ends up in the same state with conflicts resolved.
+ - Clients can have a replica of a Document representing an application model locally on several devices.
+ - Each Client can independently edit a Document on his or her local devices, even while offline.
+ - When a network connection is available, Yorkie figures out which changes need to be synced from one Client to another, and brings them into the same state.
+ - If a Document is being changed concurrently on different devices, Yorkie automatically syncs the changes so that every replica ends up in the same state with conflicts resolved.
 
 Next, let's see how to use Yorkie from [Quick Start](/docs/quick-start).

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,11 +8,11 @@ order: 10
 
 ## About Yorkie
 
-Yorkie is an open source document store for building collaborative applications such as [Google Docs](https://docs.google.com/) and [Figma](https://www.figma.com/). To achieve that, Yorkie provides synchronization primitives such as JSON-like document([CRDT](https://crdt.tech/)), [Peer Awareness](/docs/peer-awareness) and [Authentication](/docs/auth-webhook).
+Yorkie is an open source document storage for building collaborative applications such as [Google Docs](https://docs.google.com/) and [Figma](https://www.figma.com/). To achieve that, Yorkie provides synchronization primitives such as JSON-like document([CRDT](https://crdt.tech/)), [Peer Awareness](/docs/peer-awareness) and [Authentication](/docs/auth-webhook).
 
-Unlike libraries such as AutoMerge and Yjs, It contains SDK, server and DB, you can implement the co-editing feature with less effort.
+Unlike libraries such as AutoMerge and Yjs, it contains SDKs, server and DB, through which you can implement the co-editing feature with less effort.
 
-Next, let's take a look at the Yorkie's structure and how it works.
+Next, let's take a look at Yorkie's structure and how it works.
 
 ### Components
 
@@ -20,12 +20,12 @@ Yorkie consists of Client, Document, and Server.
 
 - [Client](/docs/js-sdk#client): Client is a normal client that can communicate with the Server. We can synchronize the changes of the document by using Client.
 - [Server](/docs/server): Server receives changes from Client, stores them in DB, and propagates the changes to Clients who subscribe to the Document.
-- [Document](/docs/js-sdk#document): Document is a CRDT-based data type. We can representing the model of the application. And we can edit it even while offline.
+- [Document](/docs/js-sdk#document): Document is a CRDT-based data type. We can represent the model of the application through it, and we can edit it even while offline.
 - [Project](/docs/project): Project represents your service or application in Yorkie. For example, you might have separate projects for your application.
 
 ### How it works
 
-High-level overview of Yorkie is as follows:
+A high-level overview of Yorkie is as follows:
 
 ```
  Client "A" (Go)                 Server                       MemDB or MongoDB
@@ -45,11 +45,11 @@ High-level overview of Yorkie is as follows:
 └───────────────────┘
 ```
 
-The overall flows is as follows:
+The overall flow is as follows:
 
  - Clients can have a replica of the Document representing an application model locally on several devices.
- - Each client can independently edit the document on their local device, even while offline.
+ - Each client can independently edit the document on his or her local devices, even while offline.
  - When a network connection is available, Yorkie figures out which changes need to be synced from one client to another, and brings them into the same state.
- - If the document was changed concurrently on different devices, Yorkie automatically syncs the changes, so that every replica ends up in the same state with resolving conflict.
+ - If the document is being changed concurrently on different devices, Yorkie automatically syncs the changes so that every replica ends up in the same state with conflicts resolved.
 
 Next, let's see how to use Yorkie from [Quick Start](/docs/quick-start).

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,8 +48,8 @@ A high-level overview of Yorkie is as follows:
 The overall flow is as follows:
 
  - Clients can have a replica of a Document representing an application model locally on several devices.
- - Each Client can independently edit a Document on his or her local devices, even while offline.
+ - Each Client can independently edit the Document on his or her local devices, even while offline.
  - When a network connection is available, Yorkie figures out which changes need to be synced from one Client to another, and brings them into the same state.
- - If a Document is being changed concurrently on different devices, Yorkie automatically syncs the changes so that every replica ends up in the same state with conflicts resolved.
+ - If the Document is being changed concurrently on different devices, Yorkie automatically syncs the changes so that every replica ends up in the same state with conflicts resolved.
 
 Next, let's see how to use Yorkie from [Quick Start](/docs/quick-start).

--- a/docs/js-sdk.md
+++ b/docs/js-sdk.md
@@ -8,24 +8,24 @@ order: 30
 
 ## JS SDK
 
-Through Yorkie JS SDK, you can efficiently building collaborative applications. On the client-side implementation, you can create documents that are automatically synced with remote peers with minimal effort.
+Through Yorkie JS SDK, you can efficiently build collaborative applications. On the client-side implementation, you can create Documents that are automatically synced with remote peers with minimal effort.
 
 ### Client
 
-`Client` is a normal client that can communicate with the server. It has documents and sends changes of the document in local to the server to synchronize with other replicas in remote.
+`Client` is a normal client that can communicate with the server. It has Documents and sends changes of the Document from local to the server to synchronize with other replicas in remote.
 
-#### Creating a client
+#### Creating a Client
 
-We can create a client using `new yorkie.Client()`. After the client is activated, it is connected to the server and ready to use.
+We can create a Client using `new yorkie.Client()`. After the Client has been activated, it is connected to the server and ready to use.
 
 ```javascript
 const client = new yorkie.Client('localhost:8080');
 await client.activate();
 ```
 
-#### Subscribing client events
+#### Subscribing Client events
 
-We can use `client.subscribe` to subscribe client-based events, such as `status-changed`, `stream-connection-status-changed` and `peer-changed`. 
+We can use `client.subscribe` to subscribe to client-based events, such as `status-changed`, `stream-connection-status-changed` and `peer-changed`. 
 
 ```javascript
 const unsubscribe = client.subscribe((event) => {
@@ -37,28 +37,28 @@ const unsubscribe = client.subscribe((event) => {
 });
 ```
 
-By using the value of the `stream-connection-status-changed` event, it is possible to determine whether the client is connected to the network.
+By using the value of the `stream-connection-status-changed` event, it is possible to determine whether the Client is connected to the network.
 
 If you want to know about other ClientEvents, please refer to the [ClientEventType](https://yorkie.dev/yorkie-js-sdk/yorkie-js-sdk.clienteventtype).
 
 ### Document
 
-`Document` is primary data type in Yorkie, providing a JSON-like updating experience that makes it easy to represent your application's model. `Document` can be updated without attaching it to the client, and changes are automatically propagated to other peers when attaching it to the client or when the network is restored.
+`Document` is a primary data type in Yorkie, which provides a JSON-like updating experience that makes it easy to represent your application's model. A `Document` can be updated without being attached to the client, and its changes are automatically propagated to other peers when the Document is attached to the Client or when the network is restored.
 
-#### Creating a document
+#### Creating a Document
 
-We can create a document using `yorkie.Document()`. Let's create a document with a key of document then attach it into the client.
+We can create a Document using `yorkie.Document()`. Let's create a Document with a key and attach it to the Client.
 
 ```javascript
 const doc = new yorkie.Document('doc-1');
 await client.attach(doc);
 ```
 
-After attaching the document to the client, all changes to the document are automatically synchronized with remote peers.
+After attaching the Document to the Client, all changes to the Document are automatically synchronized with remote peers.
 
-#### Editing the document
+#### Editing the Document
 
-`Document.update(changeFn, message)` enables you to modify a document. The optional `message` allows you to keep a string to the change. If the document is attached to the client, all changes are automatically synchronized with other clients.
+`Document.update(changeFn, message)` enables you to modify a Document. The optional `message` allows you to add a description to the change. If the Document is attached to the Client, all changes are automatically synchronized with other Clients.
 
 ```javascript
 const message = 'update document for test';
@@ -70,9 +70,9 @@ doc.update((root) => {
 }, message);
 ```
 
-Under the hood, `root` in the `update` function creates a `change`, a set of operations, using a JavaScript proxy. And Every element has a unique ID, created by the logical clock. This ID is used by Yorkie to track which object is which.
+Under the hood, `root` in the `update` function creates a `change`, a set of operations, using a JavaScript proxy. Every element has its unique ID, created by the logical clock. This ID is used by Yorkie to track which object is which.
 
-And you can get the contents of the document using `document.getRoot()`.
+You can get the contents of the Document using `document.getRoot()`.
 
 ```javascript
 const root = doc.getRoot();
@@ -82,9 +82,9 @@ console.log(root.obj.obj); // {"str":"a"}
 console.log(root.obj.arr); // [1,2]
 ```
 
-#### Subscribing document events
+#### Subscribing Document events
 
-A document is modified by changes generated remotely or locally in Yorkie. When the document is modified, change events occur and we can subscribe to it using `document.subscribe`. Here, we can do post-processing such as repaint in the application using the `path` of the change events.
+A Document is modified by changes generated remotely or locally in Yorkie. When the Document is modified, change events occur, to which we can subscribe using `document.subscribe`. Here, we can do post-processing such as repaint in the application using the `path` of the change events.
 
 ```javascript
 doc.subscribe((event) => {
@@ -112,7 +112,7 @@ Custom CRDT types are data types that can be used for special applications such 
 
 #### Text
 
-`Text` provides support for collaborative plain text editing. Under the hood, `Text` is represented as a list of characters. Compared to using a regular JavaScript array, Text offers better performance. And it also has selection information for sharing the cursor position.
+`Text` provides supports for collaborative plain text editing. Under the hood, `Text` is represented as a list of characters. Compared to a regular JavaScript array, Text offers better performance. It also has selection information for sharing the cursor position.
 
 ```javascript
 doc.update((root) => {
@@ -141,7 +141,7 @@ doc.update((root) => {
 An example of RichText co-editing with Quill: [Quill example](https://github.com/yorkie-team/yorkie-js-sdk/blob/main/examples/quill.html), [Demos](/demos)
 
 #### Counter
-`Counter` support numeric types that change to addition and subtraction. If numeric data needs to be modified at the same time, `Counter` should be used instead of Primitive.
+`Counter` supports numeric types that change with addition and subtraction. If a numeric data needs to be modified at the same time, `Counter` should be used instead of primitives.
 
 ```javascript
 doc.update((root) => {
@@ -154,7 +154,7 @@ doc.update((root) => {
 
 ### TypeScript Support
 
-To use document more strictly, we can use [type variable](https://www.typescriptlang.org/docs/handbook/2/generics.html) in TypeScript when creating a Document.
+To use the Document more strictly, we can use [type variable](https://www.typescriptlang.org/docs/handbook/2/generics.html) in TypeScript when creating a Document.
 
 ```typescript
 type DocType = {
@@ -174,4 +174,3 @@ doc.update((root) => {
 For details on how to use the JS SDK, please refer to [JS SDK Reference](https://yorkie.dev/yorkie-js-sdk).
 
 Next, Let's take a look at the various [Tasks](./tasks) that can be performed with Yorkie.
-

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -8,7 +8,7 @@ order: 20
 
 ## Quick Start
 
-Let's start using Yorkie with JS SDK and Server. You need an environment that can run JavaScript, such as a browser.
+Let's start using Yorkie with the JS SDK and a Server. You need an environment that can run JavaScript, such as a browser.
 
 ### Installation
 
@@ -24,40 +24,40 @@ or just include the following code in the `<head>` tag of your HTML:
 <script src="https://cdnjs.cloudflare.com/ajax/libs/yorkie-js-sdk/{{site.version}}/yorkie-js-sdk.js"></script>
 ```
 
-If you want to test Yorkie quickly, You can start `Envoy` and `Yorkie` with `docker-compose`. To start them, downloads manifests files from [docker folder](https://github.com/yorkie-team/yorkie-team.github.io/tree/main/docker), then type `docker-compose up --build -d` in the folder.
-For more details please refer to [Server for Web](./server-for-web)
+If you want to test Yorkie quickly, You can start `Envoy` and `Yorkie` with `docker-compose`. To start them, download manifest files from the [docker folder](https://github.com/yorkie-team/yorkie-team.github.io/tree/main/docker), and then type `docker-compose up --build -d` in the folder.
+For more details, please refer to [Server for Web](./server-for-web).
 
-### How to use
+### How to use Yorkie
 
-#### 1. Activating Client
+#### 1. Activating a Client
 
-First, create client with RPCAddr then activate it.
+First, create a Client with RPCAddr and activate it.
 ```javascript
 const client = new yorkie.Client('localhost:8080');
 await client.activate();
 ```
 
-#### 2. Attaching Document
+#### 2. Attaching a Document
 
-Then create a document with a key of document then attach it into the client.
+Then, create a Document with a key of Document and attach it to the Client.
 
 ```javascript
 const doc = new yorkie.Document('doc-1');
 await client.attach(doc);
 ```
 
-This automatically synchronizes all changes to the document attached to the client with the remote peers.
+This automatically synchronizes all changes to the Document attached to the Client with the remote peers.
 
-#### 3. Updating Document
+#### 3. Updating the Document
 
-Now let's make a change on the document:
+Now let's make a change on the Document:
 ```javascript
 doc.update((root) => {
   root['key'] = 'value'; // {"key":"value"}
 });
 ```
 
-The changes are applied immediately locally and propagated to other peers that have attached the document.
+The changes are immediately applied locally and propagated to other peers who subscribe to the Document.
 
 Next, let's take a look at the [JS SDK](./js-sdk).
 


### PR DESCRIPTION
Correct typos and grammatical issues in the JS SDK page