### PR TITLE
Added description for `--auth-webhook-url` flag

### DIFF
--- a/docs/auth-webhook.md
+++ b/docs/auth-webhook.md
@@ -42,8 +42,14 @@ This token will be sent to the Server upon every request from the Client.
 
 When running a Server, we can specify an Auth Webhook by the `--authorization-webhook` flag:
 
-````bash
+```bash
 $ yorkie server --authorization-webhook=http://localhost:3000/auth-hook
+```
+
+We can also update the auth-webhook-url per project. by the `--auth-webhook-url` flag:
+
+```bash
+$ yorkie project [name] --auth-webhook-url http://localhost:3000/auth-hook
 ```
 
 The Server who receives the token calls the given webhook URL before processing the requests.

--- a/docs/project.md
+++ b/docs/project.md
@@ -22,6 +22,7 @@ Usage:
 Available Commands:
   create      Create a new project
   ls          List all projects
+  update      Update a project
 
 Flags:
   -h, --help   help for project
@@ -48,6 +49,34 @@ You can create a new Project with a name using `create`.
 ```bash
 $ yorkie project create test-project
 {"id":"627c9125d02654d3f0f769d8","name":"test-project","public_key":"c9u9298qp9as73b8i190","secret_key":"c9u9298qp9as73b8i19g","auth_webhook_url":"","auth_webhook_methods":null,"created_at":"2022-05-12T04:46:29.781052056Z"}
+```
+
+#### Update a Project
+
+You can update a Project on the server using `update`.
+
+```
+Usage:
+  yorkie project update [name] [flags]
+
+Examples:
+yorkie project update name [options]
+
+Flags:
+      --auth-webhook-url string   authorization-webhook update url
+  -h, --help                      help for update
+      --name string               new project name
+```
+
+You can update a `auth-webhook-url`.
+```bash
+$ yorkie project update test-project --auth-webhook-url http://localhost:3000/webhook
+{"id":"62ebf466275b244d0d6e0cca","test-project":"new-test-project","auth_webhook_url":"http://localhost:3000/webhook","auth_webhook_methods":null,"public_key":"cblv8plcefo85rbk33fg","secret_key":"cblv8plcefo85rbk33g0","created_at":"2022-08-04T16:31:34.909Z","updated_at":"2022-08-11T14:51:20.734Z"}
+```
+You can update a Project `name`.
+```bash
+$ yorkie project update test-project --name new-test-project
+{"id":"62ebd31611e0a0e31cceee6a","name":"new-test-project","auth_webhook_url":"http://localhost:3000/webhook","auth_webhook_methods":["AttachDocument","WatchDocuments"],"public_key":"cblt65lcefodjh0aeakg","secret_key":"cblt65lcefodjh0aeal0","created_at":"2022-08-04T14:09:26.623Z","updated_at":"2022-08-11T14:58:22.11Z"}
 ```
 
 #### Using Public Key

--- a/docs/project.md
+++ b/docs/project.md
@@ -71,7 +71,7 @@ Flags:
 You can update a `auth-webhook-url`.
 ```bash
 $ yorkie project update test-project --auth-webhook-url http://localhost:3000/webhook
-{"id":"62ebf466275b244d0d6e0cca","test-project":"new-test-project","auth_webhook_url":"http://localhost:3000/webhook","auth_webhook_methods":null,"public_key":"cblv8plcefo85rbk33fg","secret_key":"cblv8plcefo85rbk33g0","created_at":"2022-08-04T16:31:34.909Z","updated_at":"2022-08-11T14:51:20.734Z"}
+{"id":"62ebf466275b244d0d6e0cca","name":"test-project","auth_webhook_url":"http://localhost:3000/webhook","auth_webhook_methods":null,"public_key":"cblv8plcefo85rbk33fg","secret_key":"cblv8plcefo85rbk33g0","created_at":"2022-08-04T16:31:34.909Z","updated_at":"2022-08-11T14:51:20.734Z"}
 ```
 You can update a Project `name`.
 ```bash

--- a/docs/project.md
+++ b/docs/project.md
@@ -68,12 +68,13 @@ Flags:
       --name string               new project name
 ```
 
-You can update a `auth-webhook-url`.
+You can update auth-webhook-url of project with `--auth-webhook-url`.
 ```bash
 $ yorkie project update test-project --auth-webhook-url http://localhost:3000/webhook
 {"id":"62ebf466275b244d0d6e0cca","name":"test-project","auth_webhook_url":"http://localhost:3000/webhook","auth_webhook_methods":null,"public_key":"cblv8plcefo85rbk33fg","secret_key":"cblv8plcefo85rbk33g0","created_at":"2022-08-04T16:31:34.909Z","updated_at":"2022-08-11T14:51:20.734Z"}
 ```
-You can update a Project `name`.
+
+You can update name of project with `--name`.
 ```bash
 $ yorkie project update test-project --name new-test-project
 {"id":"62ebd31611e0a0e31cceee6a","name":"new-test-project","auth_webhook_url":"http://localhost:3000/webhook","auth_webhook_methods":["AttachDocument","WatchDocuments"],"public_key":"cblt65lcefodjh0aeakg","secret_key":"cblt65lcefodjh0aeal0","created_at":"2022-08-04T14:09:26.623Z","updated_at":"2022-08-11T14:58:22.11Z"}


### PR DESCRIPTION
As the `--auth-webhook-url` flag feature was added, a related description was added to the doc.

https://github.com/yorkie-team/yorkie/pull/376